### PR TITLE
Print message before and after encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Simple and obvious examples for using `rust-protobuf` module were lacking, so th
 
 protoc (Protobuf Compiler)
 
+[Installation instructions](https://grpc.io/docs/protoc-installation)
+
 ### Installing Protoc on Ubuntu (and similar)
 
 `sudo apt install protobuf-compiler`
@@ -32,4 +34,4 @@ $ cargo run
 
 ## Contributions
 
-Contributions are welcome.  File an issue or PR.
+Contributions are welcome. File an issue or PR.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,10 @@ fn main() {
     out_msg.age = 25;
     out_msg.features.push("one".to_string());
     out_msg.features.push("two".to_string());
+    println!("Message request:\nout_msg {:#?}", out_msg);
 
     let out_bytes: Vec<u8> = out_msg.write_to_bytes().unwrap();
+    println!("Message request in bytes:\nout_bytes {:?}", out_bytes);
 
     // Decode example request
     let in_msg = GetRequest::parse_from_bytes(&out_bytes).unwrap();
@@ -29,8 +31,10 @@ fn main() {
     out_resp.address = "1243 main street".to_string();
     out_resp.city = "anytown".to_string();
     out_resp.zipcode = 54321;
+    println!("\nMessage response:\nout_msg {:#?}", out_resp);
 
     let out_bytes: Vec<u8> = out_resp.write_to_bytes().unwrap();
+    println!("Message response in bytes:\nout_bytes {:?}", out_bytes);
 
     // Decode example response
     let in_resp = GetResponse::parse_from_bytes(&out_bytes).unwrap();


### PR DESCRIPTION
This is a minor PR to print the message in pretty form before encoding, and then the bytes after.
I found this helpful as I wrapped my head around this.

This also added a link to installing protoc, since this is a great, beginner-friendly resource.

Result looks like this:

<img width="666" alt="Screen Shot 2022-10-02 at 12 49 10 PM" src="https://user-images.githubusercontent.com/1042667/193468485-4feca988-822d-43ed-bc5c-c27e41f62f39.png">

Thank you for making this, exactly what I needed. 🙏🏼 